### PR TITLE
Add cookie consent banner

### DIFF
--- a/locales/en/home.json
+++ b/locales/en/home.json
@@ -130,6 +130,10 @@
   "home.WriteUs.description": "Book Your Audit Today — we’ll get back to you immediately.",
   "home.WriteUs.button": "Book an audit",
 
+  "home.CookieBanner.message": "We use cookies to enhance your browsing experience and analyze our traffic. By continuing to use this site, you agree to our use of cookies.",
+  "home.CookieBanner.accept": "Accept",
+  "home.CookieBanner.ariaLabel": "Cookie usage notification",
+
   "home.Footer.contact": "contact us",
   "home.Footer.media": "social media",
   "home.Footer.resources": "resources",

--- a/locales/pl/home.json
+++ b/locales/pl/home.json
@@ -130,6 +130,10 @@
   "home.WriteUs.description": "Umów audyt już dziś — odezwiemy się natychmiast.",
   "home.WriteUs.button": "Zamów Analizę",
 
+  "home.CookieBanner.message": "Używamy plików cookie, aby ulepszać działanie strony i analizować ruch. Kontynuując korzystanie z serwisu, wyrażasz zgodę na ich użycie.",
+  "home.CookieBanner.accept": "Akceptuję",
+  "home.CookieBanner.ariaLabel": "Powiadomienie o wykorzystaniu plików cookie",
+
   "home.Footer.contact": "Skontaktuj się z nami",
   "home.Footer.media": "social media",
   "home.Footer.resources": "zasoby",

--- a/src/components/CookieBanner/CookieBanner.jsx
+++ b/src/components/CookieBanner/CookieBanner.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react"
+import { useTranslation } from "gatsby-plugin-react-i18next"
+import {
+  BannerWrapper,
+  BannerContent,
+  BannerActions,
+} from "./styled.components"
+import { RoundedButtonOrange } from "../../styled.components"
+
+const storageKey = "ros-cookie-consent"
+
+const CookieBanner = () => {
+  const { t } = useTranslation()
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    try {
+      const consent = window.localStorage.getItem(storageKey)
+      if (!consent) {
+        setIsVisible(true)
+      }
+    } catch (error) {
+      setIsVisible(true)
+    }
+  }, [])
+
+  const handleAccept = () => {
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, "accepted")
+      }
+    } catch (error) {}
+
+    setIsVisible(false)
+  }
+
+  if (!isVisible) return null
+
+  return (
+    <BannerWrapper
+      role="dialog"
+      aria-live="polite"
+      aria-label={t("home.CookieBanner.ariaLabel")}
+    >
+      <BannerContent>
+        <p className="p-new-model-16">{t("home.CookieBanner.message")}</p>
+        <BannerActions>
+          <RoundedButtonOrange type="button" onClick={handleAccept}>
+            {t("home.CookieBanner.accept")}
+          </RoundedButtonOrange>
+        </BannerActions>
+      </BannerContent>
+    </BannerWrapper>
+  )
+}
+
+export default CookieBanner

--- a/src/components/CookieBanner/styled.components.js
+++ b/src/components/CookieBanner/styled.components.js
@@ -1,0 +1,41 @@
+import styled from "styled-components"
+
+export const BannerWrapper = styled.div`
+  position: fixed;
+  z-index: 1000;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  width: min(90%, 720px);
+  pointer-events: none;
+`
+
+export const BannerContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 12, 10, 0.92);
+  box-shadow: 0px 24px 48px rgba(13, 7, 2, 0.45);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+
+  p {
+    margin: 0;
+    color: #ffe8d9;
+    line-height: 1.5;
+  }
+`
+
+export const BannerActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  @media only screen and (max-width: 640px) {
+    button {
+      width: 100%;
+    }
+  }
+`

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -16,6 +16,7 @@ import EliminateProblems from "./components/EliminateProblems/EliminateProblems"
 import HowItWorks from "./components/HowItWorks/HowItWorks"
 import OurPartners from "./components/OurPartners/OurPartners"
 import ElevenWidget from "../../components/ElevenWidget/ElevenWidget"
+import CookieBanner from "../../components/CookieBanner/CookieBanner"
 import { agentId } from "../../config/externalResources"
 
 const Home = () => {
@@ -51,6 +52,7 @@ const Home = () => {
       <PriceList t={t} />
       <WriteUs t={t} />
       <Footer t={t} />
+      <CookieBanner />
       <ElevenWidget agentId={agent} />
     </>
   )


### PR DESCRIPTION
## Summary
- add a reusable cookie consent banner component with persistent local-storage consent
- render the banner on the home page and provide English and Polish copy updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e627bfe104832ba24f32d0d5801cad